### PR TITLE
removing error alert when there's an input

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,3 +56,16 @@ function savePlayerConfig(e) {
 }
 
 playerConfigForms.addEventListener('submit', savePlayerConfig)
+
+//removing the error alert if the player starts typing in forms
+//form input
+let configInput = document.getElementById("name")
+
+ function removeErrorAlert () {
+    if(configInput.value.length > 0) {
+        playerConfigForms.firstElementChild.classList.remove("input-error")
+        userInputError.textContent = ''
+    }
+ }
+
+ configInput.addEventListener('input', removeErrorAlert)


### PR DESCRIPTION
When a clicks on submit button without any input, there's a prompt to alert the player. Now this will remove the alert automatically if the player starts to input something.